### PR TITLE
Continue instead of sleep on each queue

### DIFF
--- a/sqjobs/brokers/multiqueue.py
+++ b/sqjobs/brokers/multiqueue.py
@@ -1,6 +1,4 @@
-from time import time
-from itertools import cycle
-from collections import defaultdict
+from time import time, sleep
 
 from .standard import Standard
 
@@ -18,19 +16,25 @@ class MultiQueue(Standard):
         * queue_names: List of queue names from where to read.
         * timeout: Not used by this implementation. It's kept for compatibility.
         """
-        queue_last_check = defaultdict(int)
+        queue_last_check = {queue: 0 for queue in queue_names}
 
         # loop through the queue list forever
-        for queue_name in cycle(queue_names):
-            next_check = queue_last_check[queue_name] + self.polling_interval
+        while True:
+            for queue in queue_names:
+                next_check = queue_last_check[queue] + self.polling_interval
 
-            if next_check > int(time()):
-                continue
+                # if it's been less than `polling_time` since last check, continue
+                if next_check > int(time()):
+                    continue
 
-            # wait_time needs to be 0 or it will block in the first queue
-            payload = self.connector.dequeue(queue_name, wait_time=0)
-            if payload:
-                yield payload
-            else:
-                # only update last check when queue is empty
-                queue_last_check[queue_name] = int(time())
+                # wait_time needs to be 0 or it will block in the first queue
+                payload = self.connector.dequeue(queue, wait_time=0)
+                if payload:
+                    queue_last_check[queue] = 0
+                    yield payload
+                else:
+                    queue_last_check[queue] = int(time())
+
+            # only sleep if all queues are empty
+            if all(value != 0 for value in queue_last_check.values()):
+                sleep(self.polling_interval)

--- a/sqjobs/brokers/multiqueue.py
+++ b/sqjobs/brokers/multiqueue.py
@@ -1,4 +1,4 @@
-from time import time, sleep
+from time import time
 from itertools import cycle
 from collections import defaultdict
 
@@ -25,7 +25,7 @@ class MultiQueue(Standard):
             next_check = queue_last_check[queue_name] + self.polling_interval
 
             if next_check > int(time()):
-                sleep(next_check - int(time()))
+                continue
 
             # wait_time needs to be 0 or it will block in the first queue
             payload = self.connector.dequeue(queue_name, wait_time=0)


### PR DESCRIPTION
We only set the new `last_check` time when the queue is empty, that way sqjobs would consume more messages from said queue.

But, as it only consumes one message at a time and then keeps looping through the other queues (probably empty queues which do have a `last_check` time) it still waits for 20 seconds before dequeueing a new message.

Could this change cause any kind of performance issue?